### PR TITLE
BUGS Abierto anual

### DIFF
--- a/controllers/abiertoAnual.controller.js
+++ b/controllers/abiertoAnual.controller.js
@@ -225,7 +225,7 @@ exports.update = async (req, res) => {
     return res.status(200).json(documentoActualizado);
   } catch (error) {
     return res.status(400).json({
-      message: e.message,
+      message: error.message,
     });
   }
 };

--- a/services/abiertoAnual.service.js
+++ b/services/abiertoAnual.service.js
@@ -36,9 +36,56 @@ exports.create = async function (formData) {
 };
 
 exports.update = async function (id, update) {
-  return AbiertoAnual.findOneAndUpdate({ _id: id }, update, {
-    new: true,
+  if (!update?.facturas || !Array.isArray(update.facturas)) {
+    return AbiertoAnual.findOneAndUpdate({ _id: id }, update, {
+      new: true,
+    });
+  }
+
+  const existing = await AbiertoAnual.findById(id);
+  if (!existing) return null;
+
+  const mergedFacturas = update.facturas.map((factura, index) => {
+    const prev = existing.facturas[index] ?? null;
+
+    if (factura == null) {
+      return prev;
+    }
+
+    if (!prev) {
+      const nueva = {
+        observaciones: factura.observaciones ?? '',
+        rectificando: !!factura.rectificando,
+      };
+      if (factura.url) nueva.url = factura.url;
+      return nueva;
+    }
+
+    const merged = {
+      observaciones:
+        factura.observaciones !== undefined
+          ? factura.observaciones
+          : prev.observaciones ?? '',
+      rectificando:
+        factura.rectificando !== undefined
+          ? factura.rectificando
+          : !!prev.rectificando,
+    };
+
+    if (factura.url) {
+      merged.url = factura.url;
+    } else if (prev.url) {
+      merged.url = prev.url;
+    }
+
+    return merged;
   });
+
+  return AbiertoAnual.findOneAndUpdate(
+    { _id: id },
+    { ...update, facturas: mergedFacturas },
+    { new: true }
+  );
 };
 
 exports.updateLazy = async function (id, update) {


### PR DESCRIPTION
Trello: https://trello.com/c/JJdp9sSy
Proyecto: haciendavgesell

### Resumen del agente
### haciendavgesell/front @ feat/JJdp9sSy-bugs-abierto-anual
Agente finished en D:/dev/Redeterminación/front
Listo. Cambio mínimo en `AvanzarPaso`, case 9.

### Qué se corrigió

Antes, la rectificación manual asumía que ya existía una factura y accedía a `facturas[periodo].contenido`, lo que fallaba cuando el slot era `null` (por ejemplo, período vencido sin carga — estado 5).

Ahora:

- Si `facturas[periodo]` es `null` → se envía `{ rectificando: true }` con `status = "Incorrecto"`.
- Si existe → se preservan todos los campos existentes (`url`, `contenido`, `observaciones`, etc.) y solo se agrega `rectificando: true`.

```454:465:components/comercio/AbiertoAnualAdminCard.vue
            case 9:
                nextCard = 7;
                status[this.periodo] = "Incorrecto";
                if (facturas[this.periodo]) {
                    facturas[this.periodo] = {
                        ...facturas[this.periodo],
                        rectificando: true,
                    };
                } else {
                    facturas[this.periodo] = { rectificando: true };
                }
                break;
```

### Notas

- **Case 12** no lo toqué: solo se alcanza desde rechazo en revisión (estados 2/8), donde siempre hay factura cargada.
- El diff previo del ícono de rectificac

### haciendavgesell/back @ feat/JJdp9sSy-bugs-abierto-anual
Agente finished en D:/dev/Redeterminación/redeterminacion
## Listo — cambios aplicados (sin commit)

### Front (1/2) — `AbiertoAn